### PR TITLE
Uniform handling of array and slices in etf.TermIntoStruct

### DIFF
--- a/etf/etf_test.go
+++ b/etf/etf_test.go
@@ -1,0 +1,52 @@
+package etf
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTermIntoStruct_Slice(t *testing.T) {
+	dest := struct{ Slice []byte }{}
+
+	tests := []struct {
+		want []byte
+		term Term
+	}{
+		{[]byte{1, 2, 3}, List{1, 2, 3}},
+		{[]byte{3, 4, 5}, Tuple{3, 4, 5}},
+	}
+
+	for _, tt := range tests {
+		term := Map{"slice": tt.term}
+		if err := TermIntoStruct(term, &dest); err != nil {
+			t.Errorf("%#v: conversion failed: %v", term, err)
+		}
+
+		if !bytes.Equal(dest.Slice, tt.want) {
+			t.Errorf("%#v: got %v, want %v", term, dest.Slice, tt.want)
+		}
+	}
+}
+
+func TestTermIntoStruct_Array(t *testing.T) {
+	dest := struct{ Array [3]byte }{}
+
+	tests := []struct {
+		want [3]byte
+		term Term
+	}{
+		{[...]byte{1, 2, 3}, List{1, 2, 3}},
+		{[...]byte{3, 4, 5}, Tuple{3, 4, 5}},
+	}
+
+	for _, tt := range tests {
+		term := Map{"array": tt.term}
+		if err := TermIntoStruct(term, &dest); err != nil {
+			t.Errorf("%#v: conversion failed: %v", term, err)
+		}
+
+		if dest.Array != tt.want {
+			t.Errorf("%#v: got %v, want %v", term, dest.Array, tt.want)
+		}
+	}
+}

--- a/etf/read_test.go
+++ b/etf/read_test.go
@@ -251,7 +251,7 @@ func TestReadInt(t *testing.T) {
 	// error (bad length)
 	for _, b := range []byte{97, 98, 110, 111} {
 		if _, err := c.Read(bytes.NewBuffer([]byte{b})); err == nil {
-			t.Error("err == nil (%d)", b)
+			t.Errorf("err == nil (%d)", b)
 		}
 	}
 
@@ -401,7 +401,7 @@ func TestReadString(t *testing.T) {
 	// error (bad length)
 	for _, b := range []byte{107, 108, 109} {
 		if _, err := c.Read(bytes.NewBuffer([]byte{b})); err == nil {
-			t.Error("err == nil (%d)", b)
+			t.Errorf("err == nil (%d)", b)
 		}
 	}
 }

--- a/etf/write_test.go
+++ b/etf/write_test.go
@@ -17,7 +17,7 @@ func TestWriteAtom(t *testing.T) {
 				t.Error(in, err)
 			}
 		} else if shouldFail {
-			t.Error("err == nil (%v)", in)
+			t.Errorf("err == nil (%v)", in)
 		} else if v, err := c.Read(w); err != nil {
 			t.Error(in, err)
 		} else if l := w.Len(); l != 0 {
@@ -183,7 +183,7 @@ func TestWriteString(t *testing.T) {
 				t.Error(in, err)
 			}
 		} else if shouldFail {
-			t.Error("err == nil (%v)", in)
+			t.Errorf("err == nil (%v)", in)
 		} else if v, err := c.Read(w); err != nil {
 			t.Error(in, err)
 		} else if l := w.Len(); l != 0 {


### PR DESCRIPTION
List and tuple can be assigned to struct field of slice or array type.