### PR TITLE
handle response > 0 from EPMD

### DIFF
--- a/dist/epmd.go
+++ b/dist/epmd.go
@@ -141,6 +141,8 @@ func (e *EPMD) ResolvePort(name string) (int, error) {
 		p := binary.BigEndian.Uint16(buf[2:4])
 		// we don't use all the extra info for a while. FIXME (do we need it?)
 		return int(p), nil
+	} else if buf[1] > 0 {
+		return -1, fmt.Errorf("desired node not found")
 	} else {
 		return -1, fmt.Errorf("malformed reply - %#v", buf)
 	}


### PR DESCRIPTION
according epmd-protocol resposne > 0 is correct, so add handling for
such case.
For more information please see
http://erlang.org/doc/apps/erts/erl_dist_protocol.html#epmd-protocol